### PR TITLE
Fix for rust 1.53.0 / emcc 1.39.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/gifnksm/emscripten-sys"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.24.0"
+bindgen = "0.59.1"

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,8 @@ use std::env;
 use std::path::Path;
 
 fn main() {
+    println!("cargo:rerun-if-changed=etc/emscripten.h");
+
     let out_dir = env::var("OUT_DIR").expect("failed to get envvar OUT_DIR");
     let emscripten_dir = env::var("EMSCRIPTEN").expect("failed to get envvar EMSCRIPTEN");
 
@@ -12,14 +14,18 @@ fn main() {
     let builder = bindgen::builder()
         .header("etc/emscripten.h")
         .generate_comments(true)
-        .whitelisted_type(whitelist)
-        .whitelisted_function(whitelist)
-        .whitelisted_var(whitelist)
-        .no_unstable_rust()
+        .allowlist_type(whitelist)
+        .allowlist_function(whitelist)
+        .allowlist_var(whitelist)
         .use_core()
+        .clang_arg("-fvisibility=default") // ref: https://github.com/rust-lang/rust-bindgen/issues/1941
         .clang_arg(format!("-I{}/system/include", emscripten_dir))
         .clang_arg(format!("-I{}/system/include/libc", emscripten_dir))
         .clang_arg(format!("-I{}/system/include/libcxx", emscripten_dir))
+        .clang_arg(format!(
+            "-I{}/system/lib/libc/musl/arch/emscripten",
+            emscripten_dir
+        ))
         .clang_arg("-x")
         .clang_arg("c++")
         .clang_arg("-std=c++11")

--- a/etc/emscripten.h
+++ b/etc/emscripten.h
@@ -4,5 +4,5 @@
 #include <emscripten/html5.h>
 #include <emscripten/threading.h>
 #include <emscripten/trace.h>
-#include <emscripten/vector.h>
+// #include <emscripten/vector.h>
 #include <emscripten/vr.h>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,13 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(non_upper_case_globals)]
 
 extern crate core;
 
 extern "C" {
-    pub fn emscripten_GetProcAddress(name: *const std::os::raw::c_char)
-        -> *const std::os::raw::c_void;
+    pub fn emscripten_GetProcAddress(
+        name: *const std::os::raw::c_char,
+    ) -> *const std::os::raw::c_void;
 }
 
 include!(concat!(env!("OUT_DIR"), "/emscripten.rs"));


### PR DESCRIPTION
https://github.com/gifnksm/emscripten-sys/pull/11 & some fixes

---

Sadly, we have to use a particular version of Emscripten
ref: https://blog.therocode.net/2020/10/a-guide-to-rust-sdl2-emscripten#comment-5178721974

```
$ rustc -vV
rustc 1.53.0 (53cb7b09b 2021-06-17)
binary: rustc
commit-hash: 53cb7b09b00cbea8754ffb78e7e3cb521cb8af4b
commit-date: 2021-06-17
host: x86_64-unknown-linux-gnu
release: 1.53.0
LLVM version: 12.0.1
$ emcc -v  
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 1.39.20
clang version 12.0.0 (/b/s/w/ir/cache/git/chromium.googlesource.com-external-github.com-llvm-llvm--project 55fa315b0352b63454206600d6803fafacb42d5e)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /emsdk/upstream/bin
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/9
Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/9
Candidate multilib: .;@m64
Selected multilib: .;@m64
shared:INFO: (Emscripten: Running sanity checks)
```

It works collectly
```
$ EMSCRIPTEN="/emsdk/upstream/emscripten" EMMAKEN_CFLAGS="-s FETCH=1" cargo build --target wasm32-unknown-emscripten
   Compiling memchr v2.3.4
   Compiling libc v0.2.98
   Compiling radium v0.5.3
   Compiling glob v0.3.0
   Compiling cfg-if v1.0.0
   Compiling version_check v0.9.3
   Compiling tap v1.0.1
   Compiling log v0.4.14
   Compiling wyz v0.2.0
   Compiling bitflags v1.2.1
   Compiling proc-macro2 v1.0.28
   Compiling funty v1.1.0
   Compiling regex-syntax v0.6.25
   Compiling unicode-xid v0.2.2
   Compiling unicode-width v0.1.8
   Compiling ansi_term v0.11.0
   Compiling vec_map v0.8.2
   Compiling strsim v0.8.0
   Compiling bindgen v0.59.1
   Compiling termcolor v1.1.2
   Compiling humantime v2.1.0
   Compiling peeking_take_while v0.1.2
   Compiling lazy_static v1.4.0
   Compiling lazycell v1.3.0
   Compiling rustc-hash v1.1.0
   Compiling shlex v1.0.0
   Compiling libloading v0.7.0
   Compiling textwrap v0.11.0
   Compiling nom v6.2.1
   Compiling clang-sys v1.2.0
   Compiling aho-corasick v0.7.15
   Compiling bitvec v0.19.5
   Compiling quote v1.0.9
   Compiling atty v0.2.14
   Compiling which v3.1.1
   Compiling regex v1.4.6
   Compiling clap v2.33.3
   Compiling env_logger v0.8.4
   Compiling cexpr v0.5.0
   Compiling emscripten-sys v0.3.2 (/project/wasm_in_action_rust/emscripten-sys)
    Finished dev [unoptimized + debuginfo] target(s) in 44.71s
```
